### PR TITLE
Install bower components before starting to build apps

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -50,6 +50,9 @@ function buildApps(options) {
     appOptions.APP_DIR = appDirFile.path;
     appOptions.STAGE_APP_DIR = stageAppDir.path;
 
+    // Install app dependency
+    require('./webapp-dependency').execute(appOptions);
+
     let buildFile = utils.getFile(appDir, 'build', 'build.js');
     // A workaround for bug 1093267
     if (buildFile.exists()) {

--- a/build/webapp-dependency.js
+++ b/build/webapp-dependency.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/* global require, exports */
+
+var utils = require('utils');
+var sh = new utils.Commander('sh');
+
+exports.execute = function(options) {
+  var appName = utils.getFile(options.APP_DIR).leafName;
+  var bower = utils.getFile(options.APP_DIR, 'bower.json');
+  if (bower.exists()) {
+    // Switch to app dir and silently install bower
+    sh.initPath(utils.getEnvPath());
+    sh.run(['-c', 'cd ' + options.APP_DIR + ' && bower install -s']);
+    sh.run(['-c', 'echo "[app] bower installed on ' + appName + ' app"']);
+  }
+};

--- a/build/webapp-optimize.js
+++ b/build/webapp-optimize.js
@@ -439,7 +439,9 @@ HTMLOptimizer.prototype.inlineCSSResources = function() {
   var styles = Array.prototype.slice.call(
     doc.querySelectorAll('link[rel="stylesheet"]'));
   styles.forEach(function(oldStyle) {
-    var cssPath = oldStyle.href.split('/').slice(0, -1).join('/');
+    // Need to verify it after we move shared folder into bower component.
+    var cssPath = oldStyle.href.indexOf('shared') < 0 ?
+      oldStyle.href.split('/').slice(0, -1).join('/') : 'shared';
     var newStyle = doc.createElement('style');
     newStyle.rel = 'stylesheet';
     newStyle.type = 'text/css';


### PR DESCRIPTION
- camera app has its own bower components so skip it
- fix webapps-optimized from shared path changes
